### PR TITLE
Add Sender::createFromLoopDns() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,24 @@ and the default [`Connector`](https://github.com/reactphp/socket-client) and [DN
 
 See also [`Browser::withSender()`](#withsender) for changing the `Sender` instance during runtime.
 
+### DNS
+
+The [`Sender`](#sender) is also resposible for creating the underlying TCP/IP
+connection to the remove HTTP server and hence has to orchestrate DNS lookups.
+By default, it uses a `Connector` instance which uses Google's public DNS servers
+(`8.8.8.8`).
+
+If you need custom DNS settings, you explicitly create a [`Sender`](#sender) instance
+with your DNS server address (or `React\Dns\Resolver` instance) like this:
+
+```php
+$dns = '127.0.0.1';
+$sender = Sender::createFromLoopDns($loop, $dns);
+$browser = $browser->withSender($sender);
+```
+
+See also [`Browser::withSender()`](#withsender) for more details.
+
 ### SOCKS proxy
 
 You can also establish your outgoing connections through a SOCKS proxy server

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -16,6 +16,7 @@ use React\SocketClient\Connector;
 use React\SocketClient\SecureConnector;
 use RuntimeException;
 use React\SocketClient\ConnectorInterface;
+use React\Dns\Resolver\Resolver;
 
 class Sender
 {
@@ -27,10 +28,24 @@ class Sender
      */
     public static function createFromLoop(LoopInterface $loop)
     {
-        $dnsResolverFactory = new ResolverFactory();
-        $resolver = $dnsResolverFactory->createCached('8.8.8.8', $loop);
+        return self::createFromLoopDns($loop, '8.8.8.8');
+    }
 
-        $connector = new Connector($loop, $resolver);
+    /**
+     * create sender attached to the given event loop and DNS resolver
+     *
+     * @param LoopInterface   $loop
+     * @param Resolver|string $dns  DNS resolver instance or IP address
+     * @return self
+     */
+    public static function createFromLoopDns(LoopInterface $loop, $dns)
+    {
+        if (!($dns instanceof Resolver)) {
+            $dnsResolverFactory = new ResolverFactory();
+            $dns = $dnsResolverFactory->createCached($dns, $loop);
+        }
+
+        $connector = new Connector($loop, $dns);
 
         return self::createFromLoopConnectors($loop, $connector);
     }


### PR DESCRIPTION
This takes advantage of #38.