### PR TITLE
Remove Browser::resolve() (fully decoupled)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ mess with most of the low-level details.
     * [withSender()](#withsender)
     * [withBase()](#withbase)
     * [withoutBase()](#withoutbase)
-    * [resolve()](#resolve)
   * [ResponseInterface](#responseinterface)
   * [RequestInterface](#requestinterface)
   * [UriInterface](#uriinterface)
@@ -226,8 +225,6 @@ under a common base URI scheme.
 $newBrowser->get('/example')->then(…);
 ```
 
-See also [`resolve()`](#resolve).
-
 #### withoutBase()
 
 The `withoutBase()` method can be used to remove the base URI.
@@ -240,45 +237,6 @@ Notice that the [`Browser`](#browser) is an immutable object, i.e. the `withoutB
 actually returns a *new* [`Browser`](#browser) instance without any base URI applied.
 
 See also [`withBase()`](#withbase).
-
-#### resolve()
-
-The `resolve($uri, array $parameters)` method can be used to replace URI
-template placeholders with the given `$parameters` according to
-[RFC 6570](http://tools.ietf.org/html/rfc6570).
-It returns a string URI which can
-then be passed to the [HTTP methods](#methods).
-
-```php
-echo $browser->resolve('http://example.com/{?first,second,third}', array(
-    'first' => 'a',
-    'third' => 'c'
-));
-// http://example.com/?first=a&third=c
-```
-
-If you pass in a relative URI string, then it will also return a relative URI
-string.
-Please note that this method only proccesses URI template placeholders and does not
-take relative path referencess (such as `../` etc.) or the base URI into account.
-
-This ofen makes sense for API calls where all endpoints (URIs) are located
-under a common base URI:
-
-```php
-$browser = $browser->withBase('http://api.example.com/v3');
-
-$browser->get($browser->resolve('/fetch{/file}{?version,tag}', array(
-    'file' => 'example',
-    'version' => 1.0,
-    'tag' => 'just testing'
-)));
-// http://api.example.com/v3/fetch/example?version=1.0&tag=just%20testing
-```
-
-This uses the excellent [rize/uri-template](https://github.com/rize/UriTemplate) library under the hood.
-Please refer to [its documentation](https://github.com/rize/UriTemplate#usage) or
-[RFC 6570](http://tools.ietf.org/html/rfc6570) for more details.
 
 ### ResponseInterface
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "react/socket-client": "^0.5 || ^0.4 || ^0.3",
         "react/dns": "0.3.*|0.4.*",
         "react/promise": "^2 || ^1.1",
-        "rize/uri-template": "~0.3.0",
         "psr/http-message": "~1.0",
         "ringcentral/psr7": "~1.2"
     },

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -9,32 +9,26 @@ use Clue\React\Buzz\Message\Body;
 use Clue\React\Buzz\Message\Headers;
 use Clue\React\Buzz\Io\Sender;
 use Psr\Http\Message\UriInterface;
-use Rize\UriTemplate;
 use Clue\React\Buzz\Message\MessageFactory;
 
 class Browser
 {
     private $sender;
     private $loop;
-    private $uriTemplate;
     private $messageFactory;
     private $baseUri = null;
     private $options = array();
 
-    public function __construct(LoopInterface $loop, Sender $sender = null, UriTemplate $uriTemplate = null, MessageFactory $messageFactory = null)
+    public function __construct(LoopInterface $loop, Sender $sender = null, MessageFactory $messageFactory = null)
     {
         if ($sender === null) {
             $sender = Sender::createFromLoop($loop);
-        }
-        if ($uriTemplate === null) {
-            $uriTemplate = new UriTemplate();
         }
         if ($messageFactory === null) {
             $messageFactory = new MessageFactory();
         }
         $this->sender = $sender;
         $this->loop = $loop;
-        $this->uriTemplate = $uriTemplate;
         $this->messageFactory = $messageFactory;
     }
 
@@ -86,22 +80,6 @@ class Browser
         $transaction = new Transaction($request, $this->sender, $this->options, $this->messageFactory);
 
         return $transaction->send();
-    }
-
-    /**
-     * Resolves a relative or absolute URI by processing URI template placeholders according to RFC 6570
-     *
-     * You can either pass in a relative or absolute URI, which may or may not
-     * contain any number of URI template placeholders.
-     *
-     * @param string $uri        relative or absolute URI with URI template placeholders (RFC 6570)
-     * @param array  $parameters parameters for URI template placeholders
-     * @return string relative or absolute URI with URI template placeholders resolved according to RFC 6570
-     */
-    public function resolve($uri, array $parameters)
-    {
-        // only string URIs may contain URI template placeholders (RFC 6570)
-        return $this->uriTemplate->expand($uri, $parameters);
     }
 
     /**

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -28,43 +28,12 @@ class BrowserTest extends TestCase
         $this->assertNotSame($this->browser, $browser);
     }
 
-    public function testResolveAbsoluteWithoutPlaceholdersReturnsSame()
-    {
-        $this->assertEquals('http://example.com/', $this->browser->resolve('http://example.com/', array()));
-    }
-
-    public function testResolveRelativeWithoutPlaceholdersReturnsSame()
-    {
-        $this->assertEquals('example', $this->browser->resolve('example', array()));
-    }
-
     public function testWithBase()
     {
         $browser = $this->browser->withBase('http://example.com/root');
 
         $this->assertInstanceOf('Clue\React\Buzz\Browser', $browser);
         $this->assertNotSame($this->browser, $browser);
-    }
-
-    public function testResolveUriTemplateQueryStringWithLeadingSlash()
-    {
-        $this->assertEquals('/?q=test', $this->browser->resolve('/{?q}', array('q' => 'test')));
-    }
-
-    public function testResolveUriTemplateQueryStringOnly()
-    {
-        $this->assertEquals('?q=test', $this->browser->resolve('{?q}', array('q' => 'test')));
-    }
-
-    public function testResolveUriTemplateAbsolute()
-    {
-        $this->assertEquals('http://example.com/?q=test', $this->browser->resolve('http://example.com/{?q}', array('q' => 'test')));
-    }
-
-    public function testResolveUriTemplatePath()
-    {
-        $this->assertEquals('test', $this->browser->resolve('{+path}', array('path' => 'test')));
-        $this->assertEquals('/test', $this->browser->resolve('{+path}', array('path' => '/test')));
     }
 
     public function provideOtherUris()


### PR DESCRIPTION
This is fully decoupled ever since #54 has been merged.

If you need this feature, consider explicitly depending on rize/uri-template instead.