### PR TITLE
Forward compatibility with react/http-client v0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,15 @@ If you need custom DNS settings, you can explicitly create a [`Sender`](#sender)
 with your DNS server address (or `React\Dns\Resolver` instance) like this:
 
 ```php
+// new API for react/http 0.5
+$connector = new \React\Socket\Connector($loop, array(
+    'dns' => '127.0.0.1'
+));
+$client = new \React\HttpClient\Client($loop, $connector);
+$sender = new \Clue\Buzz\Io\Sender($client);
+$browser = $browser->withSender($sender);
+
+// deprecated legacy API
 $dns = '127.0.0.1';
 $sender = Sender::createFromLoopDns($loop, $dns);
 $browser = $browser->withSender($sender);
@@ -455,9 +464,24 @@ See also [`Browser::withSender()`](#withsender) for more details.
 ### Connection options
 
 If you need custom connector settings (DNS resolution, SSL/TLS parameters, timeouts etc.), you can explicitly pass a
-custom instance of the [`ConnectorInterface`](https://github.com/reactphp/socket-client#connectorinterface).
+custom instance of the new [`ConnectorInterface`](https://github.com/reactphp/socket#connectorinterface).
 
-The below examples assume you've installed the latest SocketClient version:
+```php
+// new API for react/http 0.5
+$connector = new \React\Socket\Connector($loop, array(
+    'dns' => '127.0.0.1'
+));
+$client = new \React\HttpClient\Client($loop, $connector);
+$sender = new \Clue\Buzz\Io\Sender($client);
+$browser = $browser->withSender($sender);
+```
+
+If you're still using the deprecated legacy Http component and you need custom
+connector settings (DNS resolution, SSL/TLS parameters, timeouts etc.), you can
+explicitly pass a custom instance of the
+[legacy `ConnectorInterface`](https://github.com/reactphp/socket-client#connectorinterface).
+
+The below examples assume you've installed the latest legacy SocketClient version:
 
 ```bash
 $ composer require react/socket-client:^0.5
@@ -468,6 +492,7 @@ You can optionally pass additional
 to the constructor like this:
 
 ```php
+// deprecated legacy API
 // use local DNS server
 $dnsResolverFactory = new DnsFactory();
 $resolver = $dnsResolverFactory->createCached('127.0.0.1', $loop);
@@ -487,6 +512,7 @@ You can optionally pass additional
 to the constructor like this:
 
 ```php
+// deprecated legacy API
 $ssl = new SecureConnector($tcp, $loop, array(
     'verify_peer' => false,
     'verify_peer_name' => false

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "require": {
     	"php": ">=5.3",
         "react/event-loop": "^0.4 || ^0.3",
-        "react/http-client": "^0.4 || ^0.3",
+        "react/http-client": "^0.5 || ^0.4 || ^0.3",
+        "react/socket": "^0.8",
         "react/socket-client": "^0.5 || ^0.4.5",
         "react/dns": "^0.4.1 || ^0.3",
         "react/promise": "^2 || ^1.1",
@@ -29,7 +30,6 @@
         "clue/socks-react": "^0.6",
         "phpunit/phpunit": "^4.5",
         "react/http": "^0.7.2",
-        "react/promise-stream": "^0.1.1",
-        "react/socket": "^0.8"
+        "react/promise-stream": "^0.1.1"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "clue/socks-react": "^0.6",
+        "clue/socks-react": "^0.8 || ^0.7",
         "phpunit/phpunit": "^4.5",
         "react/http": "^0.7.2",
         "react/promise-stream": "^0.1.1"

--- a/examples/02-concurrent.php
+++ b/examples/02-concurrent.php
@@ -9,7 +9,7 @@ $loop = React\EventLoop\Factory::create();
 $client = new Browser($loop);
 
 $client->head('http://www.github.com/clue/http-react')->then(function (ResponseInterface $response) {
-    var_dump($response->getHeaders(), (string)$result->getBody());
+    var_dump($response->getHeaders(), (string)$response->getBody());
 });
 
 $client->get('http://google.com/')->then(function (ResponseInterface $response) {

--- a/examples/11-socks-proxy.php
+++ b/examples/11-socks-proxy.php
@@ -1,23 +1,28 @@
 <?php
 
 use Clue\React\Buzz\Io\Sender;
-use React\SocketClient\TcpConnector;
-use React\EventLoop\Factory as LoopFactory;
-use Clue\React\Socks\Client as SocksClient;
 use Clue\React\Buzz\Browser;
+use Clue\React\Socks\Client as SocksClient;
 use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Factory as LoopFactory;
+use React\HttpClient\Client as HttpClient;
+use React\Socket\Connector;
 use RingCentral\Psr7;
 
 require __DIR__ . '/../vendor/autoload.php';
 
 $loop = LoopFactory::create();
 
-// create a new SOCKS client which connects to a SOCKS server listening on localhost:9050
-// not already running a SOCKS server? Try this: ssh -D 9050 localhost
-$socks = new SocksClient('127.0.0.1:9050', new TcpConnector($loop));
+// create a new SOCKS client which connects to a SOCKS server listening on localhost:1080
+// not already running a SOCKS server? Try this: ssh -D 1080 localhost
+$proxy = new SocksClient('127.0.0.1:1080', new Connector($loop));
 
 // create a Browser object that uses the SOCKS client for connections
-$sender = Sender::createFromLoopConnectors($loop, $socks);
+$client = new HttpClient($loop, new Connector($loop, array(
+    'tcp' => $proxy,
+    'dns' => false
+)));
+$sender = new Sender($client);
 $browser = new Browser($loop, $sender);
 
 // demo fetching HTTP headers (or bail out otherwise)

--- a/src/Io/ConnectionUpcaster.php
+++ b/src/Io/ConnectionUpcaster.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Clue\React\Buzz\Io;
+
+use Evenement\EventEmitter;
+use React\Socket\ConnectionInterface;
+use React\Stream\DuplexStreamInterface;
+use React\Stream\WritableStreamInterface;
+use React\Stream\Util;
+
+/**
+ * Adapter to upcast a legacy SocketClient:v0.5 Connector result to a new Socket:v0.8 ConnectionInterface
+ *
+ * @internal
+ */
+class ConnectionUpcaster extends EventEmitter implements ConnectionInterface
+{
+    private $stream;
+
+    public function __construct(DuplexStreamInterface $stream)
+    {
+        $this->stream = $stream;
+
+        Util::forwardEvents($stream, $this, array('data', 'end', 'close', 'error', 'drain'));
+    }
+
+    public function isReadable()
+    {
+        return $this->stream->isReadable();
+    }
+
+    public function isWritable()
+    {
+        return $this->isWritable();
+    }
+
+    public function pause()
+    {
+        $this->stream->pause();
+    }
+
+    public function resume()
+    {
+        $this->stream->resume();
+    }
+
+    public function pipe(WritableStreamInterface $dest, array $options = array())
+    {
+        $this->stream->pipe($dest, $options);
+    }
+
+    public function write($data)
+    {
+        return $this->stream->write($data);
+    }
+
+    public function end($data = null)
+    {
+        return $this->stream->end($data);
+    }
+
+    public function close()
+    {
+        $this->stream->close();
+        $this->removeAllListeners();
+    }
+
+    public function getRemoteAddress()
+    {
+        return null;
+    }
+
+    public function getLocalAddress()
+    {
+        return null;
+    }
+}

--- a/src/Io/ConnectorUpcaster.php
+++ b/src/Io/ConnectorUpcaster.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Clue\React\Buzz\Io;
+
+use React\Socket\ConnectorInterface;
+use React\SocketClient\ConnectorInterface as LegacyConnectorInterface;
+use React\Stream\Stream;
+
+/**
+ * Adapter to upcast a legacy SocketClient:v0.5 Connector to a new Socket:v0.8 Connector
+ *
+ * @internal
+ */
+class ConnectorUpcaster implements ConnectorInterface
+{
+    private $legacy;
+
+    public function __construct(LegacyConnectorInterface$connector)
+    {
+        $this->legacy = $connector;
+    }
+
+    public function connect($uri)
+    {
+        $parts = parse_url((strpos($uri, '://') === false ? 'tcp://' : '') . $uri);
+        if (!$parts || !isset($parts['host'], $parts['port'])) {
+            return \React\Promise\reject(new \InvalidArgumentException('Unable to parse URI'));
+        }
+
+        return $this->legacy->create($parts['host'], $parts['port'])->then(function (Stream $stream) {
+            return new ConnectionUpcaster($stream);
+        });
+    }
+}

--- a/tests/Io/SenderTest.php
+++ b/tests/Io/SenderTest.php
@@ -84,11 +84,20 @@ class SenderTest extends TestCase
     {
         $httpClientArguments = array();
         $ref = new \ReflectionClass('React\HttpClient\Client');
-        if ($ref->getConstructor()->getNumberOfRequiredParameters() == 3) {
+        $num = $ref->getConstructor()->getNumberOfRequiredParameters();
+
+        if ($num === 1) {
+            // react/http 0.5
             $httpClientArguments[] = $this->getMock('React\EventLoop\LoopInterface');
+        } else {
+            if ($num == 3) {
+                // only for react/http 0.3
+                $httpClientArguments[] = $this->getMock('React\EventLoop\LoopInterface');
+            }
+            $httpClientArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
+            $httpClientArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
         }
-        $httpClientArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
-        $httpClientArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
+
         $http = $this->getMock(
             'React\HttpClient\Client',
             array(
@@ -96,13 +105,23 @@ class SenderTest extends TestCase
             ),
             $httpClientArguments
         );
+
         $requestArguments = array();
-        $ref = new \ReflectionClass('React\HttpClient\Request');
-        if ($ref->getConstructor()->getNumberOfRequiredParameters() == 3) {
-            $requestArguments[] = $this->getMock('React\EventLoop\LoopInterface');
+        if ($num === 1) {
+            // react/http 0.5
+            $requestArguments[] = $this->getMock('React\Socket\ConnectorInterface');
+        } else {
+            // react/http 0.4/0.3
+            $ref = new \ReflectionClass('React\HttpClient\Request');
+            $num = $ref->getConstructor()->getNumberOfRequiredParameters();
+
+            if ($num === 3) {
+                $requestArguments[] = $this->getMock('React\EventLoop\LoopInterface');
+            }
+            $requestArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
         }
-        $requestArguments[] = $this->getMock('React\SocketClient\ConnectorInterface');
         $requestArguments[] = new RequestData($method, $uri, $headers, $protocolVersion);
+
         $request = $this->getMock(
             'React\HttpClient\Request',
             array(),


### PR DESCRIPTION
This PR adds support for HttpClient v0.5 without causing a BC break. This is planned for an intermediary v1.2.0 release, while future versions will have to drop support for legacy versions.

Refs #62