### PR TITLE
Forward compatibility with future Stream v1.0 and strict stream semantics

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "react/promise": "^2.2.1",
         "react/promise-stream": "^0.1.1",
         "react/socket": "^0.8",
-        "react/stream": "^0.6 || ^0.5 || ^0.4.6",
+        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6",
         "psr/http-message": "^1.0",
         "ringcentral/psr7": "^1.2"
     },

--- a/src/Message/ReadableBodyStream.php
+++ b/src/Message/ReadableBodyStream.php
@@ -22,14 +22,14 @@ class ReadableBodyStream extends EventEmitter implements ReadableStreamInterface
 
         $that = $this;
         $input->on('data', function ($data) use ($that) {
-            $that->emit('data', array($data, $that));
+            $that->emit('data', array($data));
         });
         $input->on('error', function ($error) use ($that) {
-            $that->emit('error', array($error, $that));
+            $that->emit('error', array($error));
             $that->close();
         });
         $input->on('end', function () use ($that) {
-            $that->emit('end', array($that));
+            $that->emit('end');
             $that->close();
         });
         $input->on('close', array($that, 'close'));
@@ -41,7 +41,7 @@ class ReadableBodyStream extends EventEmitter implements ReadableStreamInterface
             $this->closed = true;
             $this->input->close();
 
-            $this->emit('close', array($this));
+            $this->emit('close');
             $this->removeAllListeners();
         }
     }

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -5,11 +5,11 @@ use Clue\React\Buzz\Browser;
 use Clue\React\Buzz\Io\Sender;
 use Clue\React\Buzz\Message\ResponseException;
 use Clue\React\Block;
-use React\Stream\ReadableStream;
 use Psr\Http\Message\ServerRequestInterface;
 use React\Http\Response;
 use React\Promise\Stream;
 use React\Socket\Connector;
+use React\Stream\ThroughStream;
 
 class FunctionalBrowserTest extends TestCase
 {
@@ -176,7 +176,7 @@ class FunctionalBrowserTest extends TestCase
 
         $this->base = str_replace('tcp:', 'http:', $socket->getAddress()) . '/';
 
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
 
         $this->loop->addTimer(0.001, function () use ($stream) {
             $stream->emit('data', array('hello world'));
@@ -195,7 +195,7 @@ class FunctionalBrowserTest extends TestCase
     /** @group online */
     public function testPostStreamKnownLength()
     {
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
 
         $this->loop->addTimer(0.001, function () use ($stream) {
             $stream->emit('data', array('hello world'));
@@ -211,7 +211,7 @@ class FunctionalBrowserTest extends TestCase
     /** @group online */
     public function testPostStreamClosed()
     {
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
         $stream->close();
 
         $response = Block\await($this->browser->post($this->base . 'post', array(), $stream), $this->loop);

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -7,7 +7,7 @@ use Clue\React\Buzz\Message\MessageFactory;
 use React\Promise;
 use Clue\React\Block;
 use React\EventLoop\Factory;
-use React\Stream\ReadableStream;
+use React\Stream\ThroughStream;
 
 class TransactionTest extends TestCase
 {
@@ -37,7 +37,7 @@ class TransactionTest extends TestCase
         $messageFactory = new MessageFactory();
         $loop = Factory::create();
 
-        $stream = new ReadableStream();
+        $stream = new ThroughStream();
         $loop->addTimer(0.001, function () use ($stream) {
             $stream->emit('data', array('hello world'));
             $stream->close();


### PR DESCRIPTION
This component follows strict stream semantics. Marking this as a BC break because this PR removes undocumented and untested excessive event arguments. Newer Stream component also unblocks latest Socket component which is now compatible and will be updated in a follow-up PR.

Refs #62