### PR TITLE
Remove deprecated API and mark Sender as @internal only

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ mess with most of the low-level details.
     * [submit()](#submit)
     * [send()](#send)
     * [withOptions()](#withoptions)
-    * [withSender()](#withsender)
     * [withBase()](#withbase)
     * [withoutBase()](#withoutbase)
   * [ResponseInterface](#responseinterface)
@@ -48,7 +47,6 @@ mess with most of the low-level details.
   * [UriInterface](#uriinterface)
   * [ResponseException](#responseexception)
 * [Advanced](#advanced)
-  * [Sender](#sender)
   * [SOCKS proxy](#socks-proxy)
   * [Options](#options)
 * [Install](#install)
@@ -105,11 +103,6 @@ $connector = new \React\Socket\Connector($loop, array(
 
 $browser = new Browser($loop, $connector);
 ```
-
-Legacy notice: This project previously used different APIs that are now
-deprecated, but continue to work unchanged. This legacy API will be removed in
-a future version, so it's highly recommended to upgrade to the above API.
-See also [`Sender`](#sender).
 
 #### Methods
 
@@ -363,22 +356,6 @@ actually returns a *new* [`Browser`](#browser) instance with the [options](#opti
 
 See [options](#options) for more details.
 
-#### withSender()
-
-> [deprecated] The `Sender` is deprecated and will likely be removed in a
-  future version.
-
-The `withSender(Sender $sender)` method can be used to change the [`Sender`](#sender) instance to use:
-
-```php
-$newBrowser = $browser->withSender($sender);
-```
-
-Notice that the [`Browser`](#browser) is an immutable object, i.e. the `withSender()` method
-actually returns a *new* [`Browser`](#browser) instance with the given [`Sender`](#sender) applied.
-
-See [`Sender`](#sender) for more details.
-
 #### withBase()
 
 The `withBase($baseUri)` method can be used to change the base URI used to
@@ -456,25 +433,6 @@ The `getCode()` method can be used to return the HTTP response status code.
 The `getResponse()` method can be used to access its underlying [`ResponseInteface`](#responseinterface) object.
 
 ## Advanced
-
-### Sender
-
-> [deprecated] The `Sender` is deprecated and will likely be removed in a
-  future version.
-
-The `Sender` is responsible for passing the [`RequestInterface`](#requestinterface) objects to
-the underlying [`HttpClient`](https://github.com/reactphp/http-client) library
-and keeps track of its transmission and converts its reponses back to [`ResponseInterface`](#responseinterface) objects.
-
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage)
-and the default [`Connector`](https://github.com/reactphp/socket-client) and [DNS `Resolver`](https://github.com/reactphp/dns).
-
-See also [`Browser::withSender()`](#withsender) for changing the `Sender` instance during runtime.
-
-Legacy notice: The `Sender` class mostly exists in order to abstract changes
-on the underlying components away from this package. As such, it offers a number
-of legacy APIs that are now deprecated and no longer in active use. These APIs
-continue to work unchanged, but will be removed in a future version.
 
 ### SOCKS proxy
 

--- a/src/Browser.php
+++ b/src/Browser.php
@@ -21,23 +21,13 @@ class Browser
      * Instantiate the Browser
      *
      * @param LoopInterface $loop
-     * @param ConnectorInterface|Sender|null $connector [optional] Connector to
-     *     use. Should be `null` in order to use default Connector. Passing a
-     *     Sender instance is deprecated and only supported for BC reasons and
-     *     will be removed in future versions.
-     * @param MessageFactory $messageFactory [internal] Only used internally and
-     *     will be removed in future versions.
+     * @param ConnectorInterface|null $connector [optional] Connector to use.
+     *     Should be `null` in order to use default Connector.
      */
-    public function __construct(LoopInterface $loop, $connector = null, MessageFactory $messageFactory = null)
+    public function __construct(LoopInterface $loop, ConnectorInterface $connector = null)
     {
-        if (!$connector instanceof Sender) {
-            $connector = Sender::createFromLoop($loop, $connector);
-        }
-        if ($messageFactory === null) {
-            $messageFactory = new MessageFactory();
-        }
-        $this->sender = $connector;
-        $this->messageFactory = $messageFactory;
+        $this->sender = Sender::createFromLoop($loop, $connector);
+        $this->messageFactory = new MessageFactory();
     }
 
     public function get($url, $headers = array())
@@ -139,15 +129,6 @@ class Browser
         $browser->options = array_filter($options + $this->options, function ($value) {
             return ($value !== null);
         });
-
-        return $browser;
-    }
-
-    /** @deprecated */
-    public function withSender(Sender $sender)
-    {
-        $browser = clone $this;
-        $browser->sender = $sender;
 
         return $browser;
     }

--- a/src/Io/Sender.php
+++ b/src/Io/Sender.php
@@ -16,7 +16,20 @@ use React\Socket\ConnectorInterface;
 use React\Stream\ReadableStreamInterface;
 
 /**
- * @deprecated as of v1.4.0, see `Browser`
+ * [Internal] Sends requests and receives responses
+ *
+ * The `Sender` is responsible for passing the [`RequestInterface`](#requestinterface) objects to
+ * the underlying [`HttpClient`](https://github.com/reactphp/http-client) library
+ * and keeps track of its transmission and converts its reponses back to [`ResponseInterface`](#responseinterface) objects.
+ *
+ * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage)
+ * and the default [`Connector`](https://github.com/reactphp/socket-client) and [DNS `Resolver`](https://github.com/reactphp/dns).
+ *
+ * The `Sender` class mostly exists in order to abstract changes on the underlying
+ * components away from this package in order to provide backwards and forwards
+ * compatibility.
+ *
+ * @internal You SHOULD NOT rely on this API, it is subject to change without prior notice!
  * @see Browser
  */
 class Sender
@@ -44,32 +57,13 @@ class Sender
         return new self(new HttpClient($loop, $connector));
     }
 
-    /**
-     * [deprecated] create sender attached to the given event loop and DNS resolver
-     *
-     * @param LoopInterface   $loop
-     * @param \React\Dns\Resolver\Resolver|string $dns  DNS resolver instance or IP address
-     * @return self
-     * @deprecated as of v1.2.0, see createFromLoop()
-     * @see self::createFromLoop()
-     */
-    public static function createFromLoopDns(LoopInterface $loop, $dns)
-    {
-        return self::createFromLoop($loop, new Connector($loop, array(
-            'dns' => $dns
-        )));
-    }
-
     private $http;
 
     /**
-     * [deprecated] Instantiate Sender
+     * [internal] Instantiate Sender
      *
      * @param HttpClient $http
-     * @deprecated explicitly calling this constructor is deprecated and it
-     *     will be removed in a future version! Please use the above static
-     *     `create*()` methods instead for future compatibility
-     * @see self::createFromLoop()
+     * @internal
      */
     public function __construct(HttpClient $http)
     {

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -1,10 +1,10 @@
 <?php
 
-use Clue\React\Buzz\Browser;
-use RingCentral\Psr7\Uri;
 use Clue\React\Block;
+use Clue\React\Buzz\Browser;
 use Psr\Http\Message\RequestInterface;
 use React\Promise\Promise;
+use RingCentral\Psr7\Uri;
 
 class BrowserTest extends TestCase
 {
@@ -16,16 +16,11 @@ class BrowserTest extends TestCase
     {
         $this->loop = $this->getMock('React\EventLoop\LoopInterface');
         $this->sender = $this->getMockBuilder('Clue\React\Buzz\Io\Sender')->disableOriginalConstructor()->getMock();
-        $this->browser = new Browser($this->loop, $this->sender);
-    }
+        $this->browser = new Browser($this->loop);
 
-    public function testWithSender()
-    {
-        $sender = $this->getMockBuilder('Clue\React\Buzz\Io\Sender')->disableOriginalConstructor()->getMock();
-
-        $browser = $this->browser->withSender($sender);
-
-        $this->assertNotSame($this->browser, $browser);
+        $ref = new ReflectionProperty($this->browser, 'sender');
+        $ref->setAccessible(true);
+        $ref->setValue($this->browser, $this->sender);
     }
 
     public function testWithBase()

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -1,11 +1,10 @@
 <?php
 
-use React\EventLoop\Factory;
-use Clue\React\Buzz\Browser;
-use Clue\React\Buzz\Io\Sender;
-use Clue\React\Buzz\Message\ResponseException;
 use Clue\React\Block;
+use Clue\React\Buzz\Browser;
+use Clue\React\Buzz\Message\ResponseException;
 use Psr\Http\Message\ServerRequestInterface;
+use React\EventLoop\Factory;
 use React\Http\Response;
 use React\Promise\Stream;
 use React\Socket\Connector;
@@ -95,8 +94,7 @@ class FunctionalBrowserTest extends TestCase
             )
         ));
 
-        $sender = Sender::createFromLoop($this->loop, $connector);
-        $browser = $this->browser->withSender($sender);
+        $browser = new Browser($this->loop, $connector);
 
         $this->setExpectedException('RuntimeException');
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
@@ -115,8 +113,7 @@ class FunctionalBrowserTest extends TestCase
             )
         ));
 
-        $sender = Sender::createFromLoop($this->loop, $connector);
-        $browser = $this->browser->withSender($sender);
+        $browser = new Browser($this->loop, $connector);
 
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
     }


### PR DESCRIPTION
Builds on top of #81
Refs #62, as this allows us to keep forwards compatibility with upcoming HttpClient/Http component changes