### PR TITLE
Update Socket dependency and support Unix Domain Sockets (UDS) again

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ mess with most of the low-level details.
   * [ResponseException](#responseexception)
 * [Advanced](#advanced)
   * [SOCKS proxy](#socks-proxy)
+  * [Unix domain sockets](#unix-domain-sockets)
   * [Options](#options)
 * [Install](#install)
 * [Tests](#tests)
@@ -443,6 +444,31 @@ The SOCKS protocol operates at the TCP/IP layer and thus requires minimal effort
 This works for both plain HTTP and SSL encrypted HTTPS requests.
 
 See also the [SOCKS example](examples/11-socks-proxy.php).
+
+### Unix domain sockets
+
+By default, this library supports transport over plaintext TCP/IP and secure
+TLS connections for the `http://` and `https://` URI schemes respectively.
+This library also supports Unix domain sockets (UDS) when explicitly configured.
+
+In order to use a UDS path, you have to explicitly configure the connector to
+override the destination URI so that the hostname given in the request URI will
+no longer be used to establish the connection:
+
+```php
+$connector = new \React\Socket\FixedUriConnector(
+    'unix:///var/run/docker.sock',
+    new \React\Socket\UnixConnector($loop)
+);
+
+$browser = new Browser($loop, $connector);
+
+$client->get('http://localhost/info')->then(function (ResponseInterface $response) {
+    var_dump($response->getHeaders(), (string)$response->getBody());
+});
+```
+
+See also the [Unix Domain Sockets (UDS) example](examples/12-unix-domain-sockets.php).
 
 ### Options
 

--- a/composer.json
+++ b/composer.json
@@ -17,16 +17,16 @@
     	"php": ">=5.4",
         "psr/http-message": "^1.0",
         "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
-        "react/http-client": "^0.5",
+        "react/http-client": "^0.5.6",
         "react/promise": "^2.2.1",
         "react/promise-stream": "^0.1.1",
-        "react/socket": "^1.0 || ^0.8",
-        "react/stream": "^1.0 || ^0.7 || ^0.6 || ^0.5 || ^0.4.6",
+        "react/socket": "^1.0 || ^0.8.4",
+        "react/stream": "^1.0 || ^0.7",
         "ringcentral/psr7": "^1.2"
     },
     "require-dev": {
         "clue/block-react": "^1.0",
-        "clue/socks-react": "^0.8 || ^0.7",
+        "clue/socks-react": "^0.8",
         "phpunit/phpunit": "^4.5",
         "react/http": "^0.7.2"
     }

--- a/examples/12-unix-domain-sockets.php
+++ b/examples/12-unix-domain-sockets.php
@@ -1,0 +1,27 @@
+<?php
+
+use Clue\React\Buzz\Browser;
+use Psr\Http\Message\ResponseInterface;
+use React\EventLoop\Factory as LoopFactory;
+use React\Socket\FixedUriConnector;
+use React\Socket\UnixConnector;
+use RingCentral\Psr7;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$loop = LoopFactory::create();
+
+// create a Browser object that uses the a Unix Domain Sockets (UDS) path for all requests
+$connector = new FixedUriConnector(
+    'unix:///var/run/docker.sock',
+    new UnixConnector($loop)
+);
+
+$browser = new Browser($loop, $connector);
+
+// demo fetching HTTP headers (or bail out otherwise)
+$browser->get('http://localhost/info')->then(function (ResponseInterface $response) {
+    echo Psr7\str($response);
+}, 'printf');
+
+$loop->run();


### PR DESCRIPTION
This simple PR updates the minimum required Socket dependency to ensure these features are always available here:
* Support Unix Domain Sockets (UDS) again (https://github.com/reactphp/http-client/pull/110)
* Work around sending secure HTTPS requests with PHP < 7.1.4 (https://github.com/reactphp/http-client/pull/109)
* Support hosts file on all platforms (https://github.com/reactphp/http-client/pull/108)

Resolves / closes #82