### PR TITLE
Forward compatibility with PHPUnit 5 and PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "clue/block-react": "^1.0",
         "clue/socks-react": "^0.8",
-        "phpunit/phpunit": "^4.5",
+        "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4",
         "react/http": "^0.7.2"
     }
 }

--- a/tests/BrowserTest.php
+++ b/tests/BrowserTest.php
@@ -14,7 +14,7 @@ class BrowserTest extends TestCase
 
     public function setUp()
     {
-        $this->loop = $this->getMock('React\EventLoop\LoopInterface');
+        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
         $this->sender = $this->getMockBuilder('Clue\React\Buzz\Io\Sender')->disableOriginalConstructor()->getMock();
         $this->browser = new Browser($this->loop);
 

--- a/tests/FunctionalBrowserTest.php
+++ b/tests/FunctionalBrowserTest.php
@@ -62,12 +62,14 @@ class FunctionalBrowserTest extends TestCase
         Block\await($browser->get($this->base . 'redirect/3'), $this->loop);
     }
 
-    /** @group online */
+    /**
+     * @group online
+     * @expectedException RuntimeException
+     */
     public function testRejectingRedirectsRejects()
     {
         $browser = $this->browser->withOptions(array('maxRedirects' => 0));
 
-        $this->setExpectedException('RuntimeException');
         Block\await($browser->get($this->base . 'redirect/3'), $this->loop);
     }
 
@@ -81,7 +83,10 @@ class FunctionalBrowserTest extends TestCase
         Block\await($this->browser->get('https://www.google.com/'), $this->loop);
     }
 
-    /** @group online */
+    /**
+     * @group online
+     * @expectedException RuntimeException
+     */
     public function testVerifyPeerEnabledForBadSslRejects()
     {
         if (!function_exists('stream_socket_enable_crypto')) {
@@ -96,7 +101,6 @@ class FunctionalBrowserTest extends TestCase
 
         $browser = new Browser($this->loop, $connector);
 
-        $this->setExpectedException('RuntimeException');
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
     }
 
@@ -118,10 +122,12 @@ class FunctionalBrowserTest extends TestCase
         Block\await($browser->get('https://self-signed.badssl.com/'), $this->loop);
     }
 
-    /** @group online */
+    /**
+     * @group online
+     * @expectedException RuntimeException
+     */
     public function testInvalidPort()
     {
-        $this->setExpectedException('RuntimeException');
         Block\await($this->browser->get('http://www.google.com:443/'), $this->loop);
     }
 

--- a/tests/Io/TransactionTest.php
+++ b/tests/Io/TransactionTest.php
@@ -13,7 +13,7 @@ class TransactionTest extends TestCase
 {
     public function testReceivingErrorResponseWillRejectWithResponseException()
     {
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $response = new Response(404);
 
         // mock sender to resolve promise with the given $response in response to the given $request
@@ -24,7 +24,7 @@ class TransactionTest extends TestCase
         $promise = $transaction->send();
 
         try {
-            Block\await($promise, $this->getMock('React\EventLoop\LoopInterface'));
+            Block\await($promise, $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock());
             $this->fail();
         } catch (ResponseException $exception) {
             $this->assertEquals(404, $exception->getCode());
@@ -43,7 +43,7 @@ class TransactionTest extends TestCase
             $stream->close();
         });
 
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $response = $messageFactory->response(1.0, 200, 'OK', array(), $stream);
 
         // mock sender to resolve promise with the given $response in response to the given $request
@@ -71,7 +71,7 @@ class TransactionTest extends TestCase
         $stream->expects($this->any())->method('isReadable')->willReturn(true);
         $stream->expects($this->once())->method('close');
 
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
         $response = $messageFactory->response(1.0, 200, 'OK', array(), $stream);
 
         // mock sender to resolve promise with the given $response in response to the given $request
@@ -89,8 +89,8 @@ class TransactionTest extends TestCase
     {
         $messageFactory = new MessageFactory();
 
-        $request = $this->getMock('Psr\Http\Message\RequestInterface');
-        $response = $messageFactory->response(1.0, 200, 'OK', array(), $this->getMock('React\Stream\ReadableStreamInterface'));
+        $request = $this->getMockBuilder('Psr\Http\Message\RequestInterface')->getMock();
+        $response = $messageFactory->response(1.0, 200, 'OK', array(), $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock());
 
         // mock sender to resolve promise with the given $response in response to the given $request
         $sender = $this->getMockBuilder('Clue\React\Buzz\Io\Sender')->disableOriginalConstructor()->getMock();
@@ -99,7 +99,7 @@ class TransactionTest extends TestCase
         $transaction = new Transaction($request, $sender, array('streaming' => true), $messageFactory);
         $promise = $transaction->send();
 
-        $response = Block\await($promise, $this->getMock('React\EventLoop\LoopInterface'));
+        $response = Block\await($promise, $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock());
 
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('', (string)$response->getBody());

--- a/tests/Message/MessageFactoryTest.php
+++ b/tests/Message/MessageFactoryTest.php
@@ -85,7 +85,7 @@ class MessageFactoryTest extends TestCase
 
     public function testBodyReadableStream()
     {
-        $stream = $this->getMock('React\Stream\ReadableStreamInterface');
+        $stream = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
         $body = $this->messageFactory->body($stream);
 
         $this->assertInstanceOf('Psr\Http\Message\StreamInterface', $body);

--- a/tests/Message/ReadableBodyStreamTest.php
+++ b/tests/Message/ReadableBodyStreamTest.php
@@ -10,7 +10,7 @@ class ReadableBodyStreamTest extends TestCase
 
     public function setUp()
     {
-        $this->input = $this->getMock('React\Stream\ReadableStreamInterface');
+        $this->input = $this->getMockBuilder('React\Stream\ReadableStreamInterface')->getMock();
         $this->stream = new ReadableBodyStream($this->input);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,9 +1,11 @@
 <?php
 
+use PHPUnit\Framework\TestCase as BaseTestCase;
+
 require __DIR__ . '/../vendor/autoload.php';
 
 error_reporting(-1);
 
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends BaseTestCase
 {
 }


### PR DESCRIPTION
I've added `PHPUnit 5` support. Also, prepare for `PHPUnit 6`. I did not support version 6 already because `getMock` method was removed from it, but `createMock` isn't available in version 4. So we will need to decide: 

 ### Migrate to PHPUnit 6, drop version 4 support, as well `PHP 5.6` will become the minimum requirement or stay as we are, or stay where we are.